### PR TITLE
Fix typo in comment and evaluator.evaluate method to use the right da…

### DIFF
--- a/chapter_8_Recommender_System/Recommender_System_PySpark.ipynb
+++ b/chapter_8_Recommender_System/Recommender_System_PySpark.ipynb
@@ -516,8 +516,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#apply the RE on predictions dataframe to calculate RMSE\n",
-    "rmse=evaluator.evaluate(predictions)"
+    "#apply the RE on predicted ratings dataframe to calculate RMSE\n",
+    "rmse=evaluator.evaluate(predicted_ratings)"
    ]
   },
   {


### PR DESCRIPTION
Issue:
predictions dataframe doesn't exist. Changing to predicted_ratings

Purposed: 
-    "#apply the RE on predictions dataframe to calculate RMSE\n",
-    "rmse=evaluator.evaluate(predictions)"
+    "#apply the RE on predicted ratings dataframe to calculate RMSE\n",
+    "rmse=evaluator.evaluate(predicted_ratings)"

